### PR TITLE
Add recipe by url functionality

### DIFF
--- a/src/components/AddModal.tsx
+++ b/src/components/AddModal.tsx
@@ -4,10 +4,10 @@ import {
   StyleSheet,
   TouchableOpacity,
   Text,
-  Linking,
   ActionSheetIOS,
   ActivityIndicator,
   Alert,
+  TextInput,
 } from 'react-native';
 import Modal from 'react-native-modal';
 import Ionicons from 'react-native-vector-icons/Ionicons';
@@ -36,6 +36,8 @@ export default function AddModal({visible, onClose}: AddModalProps) {
   const theme = useTheme() as unknown as Theme;
   const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
   const [isImporting, setIsImporting] = useState(false);
+  const [showUrlInput, setShowUrlInput] = useState(false);
+  const [recipeUrl, setRecipeUrl] = useState('');
 
   const newRecipe: Recipe = {
     id: '',
@@ -52,9 +54,10 @@ export default function AddModal({visible, onClose}: AddModalProps) {
     categories: '',
   };
 
-  const handleOpenBrowser = () => {
+  const handleClose = () => {
+    setShowUrlInput(false);
+    setRecipeUrl('');
     onClose();
-    Linking.openURL('http://');
   };
 
   const handleImagesSelected = async (response: ImagePickerResponse) => {
@@ -100,7 +103,7 @@ export default function AddModal({visible, onClose}: AddModalProps) {
         about: data.about || '',
       };
 
-      onClose();
+      handleClose();
       dispatch(changeViewMode('edit'));
       navigation.navigate('RecipeDetailsScreen', {item: importedRecipe});
     } catch (err: any) {
@@ -145,104 +148,228 @@ export default function AddModal({visible, onClose}: AddModalProps) {
     );
   };
 
+  const handleUrlImport = async () => {
+    const trimmed = recipeUrl.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    setIsImporting(true);
+    try {
+      let html: string;
+      try {
+        const pageResponse = await fetch(trimmed, {
+          headers: {
+            'User-Agent':
+              'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+            Accept:
+              'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.9',
+          },
+        });
+        if (!pageResponse.ok) {
+          throw new Error(`HTTP ${pageResponse.status}`);
+        }
+        html = await pageResponse.text();
+      } catch (fetchErr: any) {
+        throw new Error(`Could not load that page: ${fetchErr.message}`);
+      }
+
+      const {data, error} = await supabase.functions.invoke('import-recipe', {
+        body: {html, url: trimmed},
+      });
+
+      if (error || !data) {
+        throw new Error(error?.message || 'Failed to extract recipe');
+      }
+
+      const importedRecipe: Recipe = {
+        id: '',
+        title: data.title || '',
+        author: data.author || '',
+        host_url: data.host_url || '',
+        host_name: data.host_name || '',
+        image: data.image || '',
+        total_time: data.total_time || '',
+        total_time_unit: data.total_time_unit || '',
+        servings: data.servings || '',
+        ingredients: data.ingredients || '',
+        instructions: data.instructions || '',
+        categories: data.categories || '',
+        about: data.about || '',
+      };
+
+      handleClose();
+      dispatch(changeViewMode('edit'));
+      navigation.navigate('RecipeDetailsScreen', {item: importedRecipe});
+    } catch (err: any) {
+      console.error('URL import error:', err.message);
+      Alert.alert(
+        'Import Failed',
+        "We couldn't import a recipe from that link. Make sure it's a recipe page and try again.",
+        [{text: 'Try Again', style: 'cancel'}],
+      );
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
   return (
     <Modal
       isVisible={visible}
-      onBackdropPress={onClose}
-      onSwipeComplete={onClose}
+      onBackdropPress={handleClose}
+      onSwipeComplete={handleClose}
       swipeDirection={['down']}
+      avoidKeyboard
       style={styles(theme).modalOverlay}>
       <View style={styles(theme).modalContainer}>
-        <TouchableOpacity style={styles(theme).closeButton} onPress={onClose}>
+        <TouchableOpacity
+          style={styles(theme).closeButton}
+          onPress={handleClose}>
           <Ionicons
             name="close-outline"
             size={24}
             color={theme.colors['toffee-400']}
           />
         </TouchableOpacity>
-        <Text style={styles(theme).modalTitle}>Add Recipe</Text>
-        <TouchableOpacity
-          style={styles(theme).modalButtonContainer}
-          onPress={handleOpenBrowser}>
-          <View style={styles(theme).modalButtonIcon}>
-            <Ionicons
-              name="globe-outline"
-              size={24}
-              color={theme.colors['neutral-800']}
-            />
-          </View>
-          <View style={styles(theme).modalButtonTextContainer}>
-            <Text style={styles(theme).modalButtonText}>Open browser</Text>
-            <Text style={styles(theme).modalButtonSubtext}>
-              Import recipes from your browser via share sheet
-            </Text>
-          </View>
-          <Ionicons
-            name="arrow-forward-outline"
-            size={24}
-            color={theme.colors['neutral-800']}
-          />
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles(theme).modalButtonContainer}
-          onPress={handleSnapPhoto}
-          disabled={isImporting}>
-          <View style={styles(theme).modalButtonIcon}>
-            {isImporting ? (
-              <ActivityIndicator
-                size="small"
-                color={theme.colors['neutral-800']}
-              />
-            ) : (
+
+        {showUrlInput ? (
+          <>
+            <TouchableOpacity
+              style={styles(theme).backButton}
+              onPress={() => {
+                setShowUrlInput(false);
+                setRecipeUrl('');
+              }}>
               <Ionicons
-                name="camera-outline"
+                name="arrow-back-outline"
+                size={20}
+                color={theme.colors['toffee-400']}
+              />
+            </TouchableOpacity>
+            <Text style={styles(theme).modalTitle}>Paste a link</Text>
+            <View style={styles(theme).urlInputContainer}>
+              <TextInput
+                style={styles(theme).urlInput}
+                placeholder="https://..."
+                placeholderTextColor={theme.colors['toffee-400']}
+                value={recipeUrl}
+                onChangeText={setRecipeUrl}
+                autoCapitalize="none"
+                autoCorrect={false}
+                keyboardType="url"
+                returnKeyType="go"
+                onSubmitEditing={handleUrlImport}
+                autoFocus
+              />
+              <TouchableOpacity
+                style={[
+                  styles(theme).importButton,
+                  (!recipeUrl.trim() || isImporting) &&
+                    styles(theme).importButtonDisabled,
+                ]}
+                onPress={handleUrlImport}
+                disabled={!recipeUrl.trim() || isImporting}>
+                {isImporting ? (
+                  <ActivityIndicator
+                    size="small"
+                    color={theme.colors['neutral-100']}
+                  />
+                ) : (
+                  <Text style={styles(theme).importButtonText}>Import</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          </>
+        ) : (
+          <>
+            <Text style={styles(theme).modalTitle}>Add Recipe</Text>
+            <TouchableOpacity
+              style={styles(theme).modalButtonContainer}
+              onPress={() => setShowUrlInput(true)}>
+              <View style={styles(theme).modalButtonIcon}>
+                <Ionicons
+                  name="link-outline"
+                  size={24}
+                  color={theme.colors['neutral-800']}
+                />
+              </View>
+              <View style={styles(theme).modalButtonTextContainer}>
+                <Text style={styles(theme).modalButtonText}>Paste a link</Text>
+                <Text style={styles(theme).modalButtonSubtext}>
+                  Import a recipe by pasting its URL
+                </Text>
+              </View>
+              <Ionicons
+                name="arrow-forward-outline"
                 size={24}
                 color={theme.colors['neutral-800']}
               />
-            )}
-          </View>
-          <View style={styles(theme).modalButtonTextContainer}>
-            <Text style={styles(theme).modalButtonText}>Snap a photo</Text>
-            <Text style={styles(theme).modalButtonSubtext}>
-              Turn recipe cards and cookbook pages into digital recipes
-            </Text>
-          </View>
-          {isImporting ? null : (
-            <Ionicons
-              name="arrow-forward-outline"
-              size={24}
-              color={theme.colors['neutral-800']}
-            />
-          )}
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles(theme).modalButtonContainer}
-          onPress={() => {
-            onClose();
-            dispatch(changeViewMode('edit'));
-            navigation.navigate('RecipeDetailsScreen', {
-              item: newRecipe,
-            });
-          }}>
-          <View style={styles(theme).modalButtonIcon}>
-            <Ionicons
-              name="pencil-outline"
-              size={24}
-              color={theme.colors['neutral-800']}
-            />
-          </View>
-          <View style={styles(theme).modalButtonTextContainer}>
-            <Text style={styles(theme).modalButtonText}>Write your own</Text>
-            <Text style={styles(theme).modalButtonSubtext}>
-              Add custom ingredients and cooking steps from scratch
-            </Text>
-          </View>
-          <Ionicons
-            name="arrow-forward-outline"
-            size={24}
-            color={theme.colors['neutral-800']}
-          />
-        </TouchableOpacity>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles(theme).modalButtonContainer}
+              onPress={handleSnapPhoto}
+              disabled={isImporting}>
+              <View style={styles(theme).modalButtonIcon}>
+                {isImporting ? (
+                  <ActivityIndicator
+                    size="small"
+                    color={theme.colors['neutral-800']}
+                  />
+                ) : (
+                  <Ionicons
+                    name="camera-outline"
+                    size={24}
+                    color={theme.colors['neutral-800']}
+                  />
+                )}
+              </View>
+              <View style={styles(theme).modalButtonTextContainer}>
+                <Text style={styles(theme).modalButtonText}>Snap a photo</Text>
+                <Text style={styles(theme).modalButtonSubtext}>
+                  Turn recipe cards and cookbook pages into digital recipes
+                </Text>
+              </View>
+              {isImporting ? null : (
+                <Ionicons
+                  name="arrow-forward-outline"
+                  size={24}
+                  color={theme.colors['neutral-800']}
+                />
+              )}
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles(theme).modalButtonContainer}
+              onPress={() => {
+                handleClose();
+                dispatch(changeViewMode('edit'));
+                navigation.navigate('RecipeDetailsScreen', {
+                  item: newRecipe,
+                });
+              }}>
+              <View style={styles(theme).modalButtonIcon}>
+                <Ionicons
+                  name="pencil-outline"
+                  size={24}
+                  color={theme.colors['neutral-800']}
+                />
+              </View>
+              <View style={styles(theme).modalButtonTextContainer}>
+                <Text style={styles(theme).modalButtonText}>
+                  Write your own
+                </Text>
+                <Text style={styles(theme).modalButtonSubtext}>
+                  Add custom ingredients and cooking steps from scratch
+                </Text>
+              </View>
+              <Ionicons
+                name="arrow-forward-outline"
+                size={24}
+                color={theme.colors['neutral-800']}
+              />
+            </TouchableOpacity>
+          </>
+        )}
       </View>
     </Modal>
   );
@@ -312,5 +439,40 @@ const styles = (theme: Theme) =>
       top: 10,
       padding: 6,
       zIndex: 1,
+    },
+    backButton: {
+      position: 'absolute',
+      left: 12,
+      top: 10,
+      padding: 6,
+      zIndex: 1,
+    },
+    urlInputContainer: {
+      marginHorizontal: 30,
+      marginBottom: 30,
+      gap: 12,
+    },
+    urlInput: {
+      ...theme.typography.h3,
+      color: theme.colors['neutral-800'],
+      borderWidth: 1,
+      borderColor: theme.colors['neutral-300'],
+      borderRadius: 12,
+      paddingHorizontal: 16,
+      paddingVertical: 14,
+      backgroundColor: theme.colors['neutral-100'],
+    },
+    importButton: {
+      backgroundColor: theme.colors['neutral-800'],
+      borderRadius: 12,
+      paddingVertical: 14,
+      alignItems: 'center',
+    },
+    importButtonDisabled: {
+      opacity: 0.4,
+    },
+    importButtonText: {
+      ...theme.typography['h2-emphasized'],
+      color: theme.colors['neutral-100'],
     },
   });

--- a/supabase/functions/_shared/recipeUtils.ts
+++ b/supabase/functions/_shared/recipeUtils.ts
@@ -18,3 +18,334 @@ export function splitNumberedInstructions(instructions: string): string {
     .filter(s => s.length > 0);
   return parts.length > 1 ? parts.join('\n') : instructions;
 }
+
+export interface RecipeResult {
+  title: string;
+  author: string;
+  original_url: string;
+  host_url: string;
+  host_name: string;
+  categories: string;
+  image: string;
+  ingredients: string;
+  instructions: string;
+  total_time: string;
+  total_time_unit: string;
+  servings: string;
+  about: string;
+}
+
+// --- JSON-LD extraction ---
+
+export function extractJsonLd(html: string): string | null {
+  const pattern =
+    /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(html)) !== null) {
+    const block = match[1];
+    if (block.includes('"Recipe"') || block.includes('"@type":"Recipe"')) {
+      return block;
+    }
+  }
+  return null;
+}
+
+export function formatRecipeFromJsonLd(
+  jsonld: string,
+  sourceUrl: string,
+): RecipeResult | null {
+  let jsonAny: unknown;
+  try {
+    jsonAny = JSON.parse(jsonld);
+  } catch {
+    return null;
+  }
+
+  const recipeObj = findRecipeObject(jsonAny);
+  if (!recipeObj) return null;
+
+  let originalUrl = sourceUrl;
+  let hostUrl = '';
+  let hostName = '';
+  try {
+    const parsed = new URL(sourceUrl);
+    hostUrl = `${parsed.protocol}//${parsed.host}`;
+    hostName = parsed.hostname;
+  } catch {
+    // invalid URL — leave blank
+  }
+
+  const title = extractString('name', recipeObj);
+  const author = extractAuthor(recipeObj);
+  const categories = extractCategories(recipeObj, title);
+  const image = extractImage(recipeObj);
+  const ingredientsArray = extractStringArray('recipeIngredient', recipeObj);
+  const ingredients = ingredientsArray.map(i => cleanIngredients(i)).join('\n');
+  const instructions = extractInstructions(recipeObj);
+  const [totalTime, totalTimeUnit] = extractTime(recipeObj);
+  const servings = extractServings(recipeObj);
+  const about = extractString('description', recipeObj);
+
+  return {
+    title,
+    author,
+    original_url: originalUrl,
+    host_url: hostUrl,
+    host_name: hostName,
+    categories,
+    image,
+    ingredients,
+    instructions,
+    total_time: totalTime,
+    total_time_unit: totalTimeUnit,
+    servings,
+    about,
+  };
+}
+
+type JsonObject = Record<string, unknown>;
+
+function isRecipeType(obj: JsonObject): boolean {
+  const type = obj['@type'];
+  if (typeof type === 'string') return type === 'Recipe';
+  if (Array.isArray(type)) return (type as string[]).includes('Recipe');
+  return false;
+}
+
+function findRecipeObject(json: unknown): JsonObject | null {
+  if (Array.isArray(json)) {
+    return (json as JsonObject[]).find(isRecipeType) ?? null;
+  }
+  if (json && typeof json === 'object') {
+    const obj = json as JsonObject;
+    if (isRecipeType(obj)) return obj;
+    const graph = obj['@graph'];
+    if (Array.isArray(graph)) {
+      return (graph as JsonObject[]).find(isRecipeType) ?? null;
+    }
+    const items = obj['itemListElement'];
+    if (Array.isArray(items)) {
+      for (const item of items as JsonObject[]) {
+        const inner = item['item'] as JsonObject | undefined;
+        if (inner && isRecipeType(inner)) return inner;
+      }
+    }
+  }
+  return null;
+}
+
+function extractString(key: string, obj: JsonObject): string {
+  const val = obj[key];
+  if (typeof val === 'string') return val;
+  if (Array.isArray(val) && typeof val[0] === 'string') return val[0];
+  return '';
+}
+
+function extractStringArray(key: string, obj: JsonObject): string[] {
+  const val = obj[key];
+  if (Array.isArray(val)) {
+    return (val as unknown[])
+      .map(v => {
+        if (typeof v === 'string') return v;
+        if (v && typeof v === 'object') {
+          const o = v as JsonObject;
+          return (o['@value'] ?? o['name'] ?? '') as string;
+        }
+        return '';
+      })
+      .filter(s => s.length > 0);
+  }
+  if (typeof val === 'string') return [val];
+  return [];
+}
+
+function extractAuthor(obj: JsonObject): string {
+  const author = obj['author'];
+  if (Array.isArray(author) && author.length > 0) {
+    return extractString('name', author[0] as JsonObject);
+  }
+  if (author && typeof author === 'object') {
+    return extractString('name', author as JsonObject);
+  }
+  return extractString('author', obj);
+}
+
+function extractCategories(obj: JsonObject, title: string): string {
+  const cats: string[] = [];
+
+  for (const key of ['recipeCategory', 'recipeCuisine']) {
+    if (cats.length >= 2) break;
+    for (const val of extractStringArray(key, obj).map(s => s.toLowerCase())) {
+      if (val && !cats.includes(val)) {
+        cats.push(val);
+        if (cats.length >= 2) break;
+      }
+    }
+  }
+
+  if (cats.length < 2) {
+    const keywords = extractString('keywords', obj)
+      .split(',')
+      .map(s => s.trim().toLowerCase())
+      .filter(s => s.length > 0);
+    for (const kw of keywords) {
+      if (cats.length >= 2) break;
+      if (!cats.includes(kw)) cats.push(kw);
+    }
+  }
+
+  if (cats.length < 2 && title) {
+    const stopWords = new Set([
+      'delicious',
+      'easy',
+      'quick',
+      'best',
+      'homemade',
+      'perfect',
+      'simple',
+      'amazing',
+      'the',
+      'a',
+      'an',
+      'and',
+      'or',
+      'with',
+      'for',
+      'in',
+      'to',
+      'of',
+      'my',
+      'dish',
+      'bowl',
+      'recipe',
+      'meal',
+      'food',
+    ]);
+    const words = title
+      .split(/[^a-zA-Z]+/)
+      .map(w => w.toLowerCase())
+      .filter(w => w.length >= 3 && !stopWords.has(w));
+    for (const word of words) {
+      if (cats.length >= 2) break;
+      if (!cats.includes(word)) cats.push(word);
+    }
+  }
+
+  return cats.join(',');
+}
+
+function extractImage(obj: JsonObject): string {
+  const image = obj['image'];
+  if (typeof image === 'string') return image;
+  if (Array.isArray(image)) {
+    const first = image[0];
+    if (typeof first === 'string') return first;
+    if (first && typeof first === 'object') {
+      return extractString('url', first as JsonObject);
+    }
+  }
+  if (image && typeof image === 'object') {
+    return extractString('url', image as JsonObject);
+  }
+  return '';
+}
+
+function extractInstructions(obj: JsonObject): string {
+  const raw = obj['recipeInstructions'];
+  let joined: string;
+
+  if (Array.isArray(raw)) {
+    const steps = (raw as unknown[])
+      .flatMap(step => {
+        if (typeof step === 'string') return [step];
+        if (step && typeof step === 'object') {
+          const s = step as JsonObject;
+          // HowToSection — recurse into itemListElement
+          if (Array.isArray(s['itemListElement'])) {
+            return (s['itemListElement'] as JsonObject[])
+              .map(sub => (sub['text'] ?? sub['name'] ?? '') as string)
+              .filter(t => t.length > 0);
+          }
+          return [(s['text'] ?? s['@value'] ?? s['name'] ?? '') as string];
+        }
+        return [''];
+      })
+      .filter(s => s.length > 0);
+    joined = steps.join('\n');
+  } else if (typeof raw === 'string') {
+    joined = raw;
+  } else {
+    return '';
+  }
+
+  return splitNumberedInstructions(joined);
+}
+
+function parseISO8601Duration(
+  duration: string,
+): {minutes: number; unit: string} | null {
+  const match = duration.match(
+    /P(?:\d+Y)?(?:\d+M)?(?:\d+D)?T(?:(\d+)H)?(?:(\d+)M)?(?:\d+(?:\.\d+)?S)?/,
+  );
+  if (!match) return null;
+  const hours = parseInt(match[1] ?? '0', 10) || 0;
+  const minutes = parseInt(match[2] ?? '0', 10) || 0;
+  const total = hours * 60 + minutes;
+  return total > 0 ? {minutes: total, unit: 'min'} : null;
+}
+
+function extractFirstNumber(s: string): number | null {
+  const m = s.match(/(\d+)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+function extractTime(obj: JsonObject): [string, string] {
+  const totalTime = obj['totalTime'];
+  if (typeof totalTime === 'string') {
+    const parsed = parseISO8601Duration(totalTime);
+    if (parsed) return [String(parsed.minutes), parsed.unit];
+    if (!totalTime.startsWith('P')) {
+      const num = totalTime.replace(/\D/g, '');
+      if (num) {
+        const unit = /H|HOUR/i.test(totalTime) ? 'hr' : 'min';
+        return [num, unit];
+      }
+    }
+  }
+
+  const prepTime = obj['prepTime'];
+  const cookTime = obj['cookTime'];
+  if (typeof prepTime === 'string' && typeof cookTime === 'string') {
+    const prepMins = parseISO8601Duration(prepTime)?.minutes ?? 0;
+    const cookMins = parseISO8601Duration(cookTime)?.minutes ?? 0;
+    if (prepMins > 0 || cookMins > 0) {
+      const total = prepMins + cookMins;
+      return [String(total), 'min'];
+    }
+    const num = cookTime.replace(/\D/g, '');
+    if (num) {
+      const unit = /H|HOUR/i.test(cookTime) ? 'hr' : 'min';
+      return [num, unit];
+    }
+  }
+
+  return ['', ''];
+}
+
+function extractServings(obj: JsonObject): string {
+  const raw = obj['recipeYield'];
+  if (typeof raw === 'string') {
+    const n = extractFirstNumber(raw);
+    return n !== null ? String(n) : '';
+  }
+  if (typeof raw === 'number') return String(Math.round(raw));
+  if (Array.isArray(raw) && raw.length > 0) {
+    const first = raw[0];
+    if (typeof first === 'number') return String(Math.round(first));
+    if (typeof first === 'string') {
+      const n = extractFirstNumber(first);
+      return n !== null ? String(n) : '';
+    }
+  }
+  return '';
+}

--- a/supabase/functions/_shared/recipeUtils.ts
+++ b/supabase/functions/_shared/recipeUtils.ts
@@ -62,7 +62,9 @@ export function formatRecipeFromJsonLd(
   }
 
   const recipeObj = findRecipeObject(jsonAny);
-  if (!recipeObj) return null;
+  if (!recipeObj) {
+    return null;
+  }
 
   let originalUrl = sourceUrl;
   let hostUrl = '';
@@ -107,8 +109,12 @@ type JsonObject = Record<string, unknown>;
 
 function isRecipeType(obj: JsonObject): boolean {
   const type = obj['@type'];
-  if (typeof type === 'string') return type === 'Recipe';
-  if (Array.isArray(type)) return (type as string[]).includes('Recipe');
+  if (typeof type === 'string') {
+    return type === 'Recipe';
+  }
+  if (Array.isArray(type)) {
+    return (type as string[]).includes('Recipe');
+  }
   return false;
 }
 
@@ -118,16 +124,20 @@ function findRecipeObject(json: unknown): JsonObject | null {
   }
   if (json && typeof json === 'object') {
     const obj = json as JsonObject;
-    if (isRecipeType(obj)) return obj;
+    if (isRecipeType(obj)) {
+      return obj;
+    }
     const graph = obj['@graph'];
     if (Array.isArray(graph)) {
       return (graph as JsonObject[]).find(isRecipeType) ?? null;
     }
-    const items = obj['itemListElement'];
+    const items = obj.itemListElement;
     if (Array.isArray(items)) {
       for (const item of items as JsonObject[]) {
-        const inner = item['item'] as JsonObject | undefined;
-        if (inner && isRecipeType(inner)) return inner;
+        const inner = item.item as JsonObject | undefined;
+        if (inner && isRecipeType(inner)) {
+          return inner;
+        }
       }
     }
   }
@@ -136,8 +146,12 @@ function findRecipeObject(json: unknown): JsonObject | null {
 
 function extractString(key: string, obj: JsonObject): string {
   const val = obj[key];
-  if (typeof val === 'string') return val;
-  if (Array.isArray(val) && typeof val[0] === 'string') return val[0];
+  if (typeof val === 'string') {
+    return val;
+  }
+  if (Array.isArray(val) && typeof val[0] === 'string') {
+    return val[0];
+  }
   return '';
 }
 
@@ -146,21 +160,25 @@ function extractStringArray(key: string, obj: JsonObject): string[] {
   if (Array.isArray(val)) {
     return (val as unknown[])
       .map(v => {
-        if (typeof v === 'string') return v;
+        if (typeof v === 'string') {
+          return v;
+        }
         if (v && typeof v === 'object') {
           const o = v as JsonObject;
-          return (o['@value'] ?? o['name'] ?? '') as string;
+          return (o['@value'] ?? o.name ?? '') as string;
         }
         return '';
       })
       .filter(s => s.length > 0);
   }
-  if (typeof val === 'string') return [val];
+  if (typeof val === 'string') {
+    return [val];
+  }
   return [];
 }
 
 function extractAuthor(obj: JsonObject): string {
-  const author = obj['author'];
+  const author = obj.author;
   if (Array.isArray(author) && author.length > 0) {
     return extractString('name', author[0] as JsonObject);
   }
@@ -174,11 +192,15 @@ function extractCategories(obj: JsonObject, title: string): string {
   const cats: string[] = [];
 
   for (const key of ['recipeCategory', 'recipeCuisine']) {
-    if (cats.length >= 2) break;
+    if (cats.length >= 2) {
+      break;
+    }
     for (const val of extractStringArray(key, obj).map(s => s.toLowerCase())) {
       if (val && !cats.includes(val)) {
         cats.push(val);
-        if (cats.length >= 2) break;
+        if (cats.length >= 2) {
+          break;
+        }
       }
     }
   }
@@ -189,8 +211,12 @@ function extractCategories(obj: JsonObject, title: string): string {
       .map(s => s.trim().toLowerCase())
       .filter(s => s.length > 0);
     for (const kw of keywords) {
-      if (cats.length >= 2) break;
-      if (!cats.includes(kw)) cats.push(kw);
+      if (cats.length >= 2) {
+        break;
+      }
+      if (!cats.includes(kw)) {
+        cats.push(kw);
+      }
     }
   }
 
@@ -226,8 +252,12 @@ function extractCategories(obj: JsonObject, title: string): string {
       .map(w => w.toLowerCase())
       .filter(w => w.length >= 3 && !stopWords.has(w));
     for (const word of words) {
-      if (cats.length >= 2) break;
-      if (!cats.includes(word)) cats.push(word);
+      if (cats.length >= 2) {
+        break;
+      }
+      if (!cats.includes(word)) {
+        cats.push(word);
+      }
     }
   }
 
@@ -235,11 +265,15 @@ function extractCategories(obj: JsonObject, title: string): string {
 }
 
 function extractImage(obj: JsonObject): string {
-  const image = obj['image'];
-  if (typeof image === 'string') return image;
+  const image = obj.image;
+  if (typeof image === 'string') {
+    return image;
+  }
   if (Array.isArray(image)) {
     const first = image[0];
-    if (typeof first === 'string') return first;
+    if (typeof first === 'string') {
+      return first;
+    }
     if (first && typeof first === 'object') {
       return extractString('url', first as JsonObject);
     }
@@ -251,22 +285,24 @@ function extractImage(obj: JsonObject): string {
 }
 
 function extractInstructions(obj: JsonObject): string {
-  const raw = obj['recipeInstructions'];
+  const raw = obj.recipeInstructions;
   let joined: string;
 
   if (Array.isArray(raw)) {
     const steps = (raw as unknown[])
       .flatMap(step => {
-        if (typeof step === 'string') return [step];
+        if (typeof step === 'string') {
+          return [step];
+        }
         if (step && typeof step === 'object') {
           const s = step as JsonObject;
           // HowToSection — recurse into itemListElement
-          if (Array.isArray(s['itemListElement'])) {
-            return (s['itemListElement'] as JsonObject[])
-              .map(sub => (sub['text'] ?? sub['name'] ?? '') as string)
+          if (Array.isArray(s.itemListElement)) {
+            return (s.itemListElement as JsonObject[])
+              .map(sub => (sub.text ?? sub.name ?? '') as string)
               .filter(t => t.length > 0);
           }
-          return [(s['text'] ?? s['@value'] ?? s['name'] ?? '') as string];
+          return [(s.text ?? s['@value'] ?? s.name ?? '') as string];
         }
         return [''];
       })
@@ -287,7 +323,9 @@ function parseISO8601Duration(
   const match = duration.match(
     /P(?:\d+Y)?(?:\d+M)?(?:\d+D)?T(?:(\d+)H)?(?:(\d+)M)?(?:\d+(?:\.\d+)?S)?/,
   );
-  if (!match) return null;
+  if (!match) {
+    return null;
+  }
   const hours = parseInt(match[1] ?? '0', 10) || 0;
   const minutes = parseInt(match[2] ?? '0', 10) || 0;
   const total = hours * 60 + minutes;
@@ -300,10 +338,12 @@ function extractFirstNumber(s: string): number | null {
 }
 
 function extractTime(obj: JsonObject): [string, string] {
-  const totalTime = obj['totalTime'];
+  const totalTime = obj.totalTime;
   if (typeof totalTime === 'string') {
     const parsed = parseISO8601Duration(totalTime);
-    if (parsed) return [String(parsed.minutes), parsed.unit];
+    if (parsed) {
+      return [String(parsed.minutes), parsed.unit];
+    }
     if (!totalTime.startsWith('P')) {
       const num = totalTime.replace(/\D/g, '');
       if (num) {
@@ -313,8 +353,8 @@ function extractTime(obj: JsonObject): [string, string] {
     }
   }
 
-  const prepTime = obj['prepTime'];
-  const cookTime = obj['cookTime'];
+  const prepTime = obj.prepTime;
+  const cookTime = obj.cookTime;
   if (typeof prepTime === 'string' && typeof cookTime === 'string') {
     const prepMins = parseISO8601Duration(prepTime)?.minutes ?? 0;
     const cookMins = parseISO8601Duration(cookTime)?.minutes ?? 0;
@@ -333,15 +373,19 @@ function extractTime(obj: JsonObject): [string, string] {
 }
 
 function extractServings(obj: JsonObject): string {
-  const raw = obj['recipeYield'];
+  const raw = obj.recipeYield;
   if (typeof raw === 'string') {
     const n = extractFirstNumber(raw);
     return n !== null ? String(n) : '';
   }
-  if (typeof raw === 'number') return String(Math.round(raw));
+  if (typeof raw === 'number') {
+    return String(Math.round(raw));
+  }
   if (Array.isArray(raw) && raw.length > 0) {
     const first = raw[0];
-    if (typeof first === 'number') return String(Math.round(first));
+    if (typeof first === 'number') {
+      return String(Math.round(first));
+    }
     if (typeof first === 'string') {
       const n = extractFirstNumber(first);
       return n !== null ? String(n) : '';

--- a/supabase/functions/import-recipe/index.ts
+++ b/supabase/functions/import-recipe/index.ts
@@ -2,6 +2,8 @@ import '@supabase/functions-js/edge-runtime.d.ts';
 import {
   cleanIngredients,
   splitNumberedInstructions,
+  extractJsonLd,
+  formatRecipeFromJsonLd,
 } from '../_shared/recipeUtils.ts';
 
 const CORS_HEADERS = {
@@ -9,6 +11,9 @@ const CORS_HEADERS = {
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type',
 };
+
+const USER_AGENT =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
 
 function stripNonContentHTML(html: string): string {
   let cleaned = html;
@@ -37,6 +42,56 @@ function stripNonContentHTML(html: string): string {
   return cleaned;
 }
 
+function assertPublicUrl(urlString: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('Only http and https URLs are allowed');
+  }
+
+  const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+
+  if (host === 'localhost' || host === '::1' || host === '0.0.0.0') {
+    throw new Error('Private URLs are not allowed');
+  }
+
+  if (host.startsWith('fe80')) {
+    throw new Error('Private URLs are not allowed');
+  }
+
+  const ipv4 = host.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (ipv4) {
+    const [a, b] = [Number(ipv4[1]), Number(ipv4[2])];
+    if (
+      a === 127 ||
+      a === 10 ||
+      a === 0 ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 169 && b === 254)
+    ) {
+      throw new Error('Private URLs are not allowed');
+    }
+  }
+}
+
+async function fetchHtmlFromUrl(url: string): Promise<string> {
+  assertPublicUrl(url);
+  const response = await fetch(url, {
+    headers: {'User-Agent': USER_AGENT},
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch URL: HTTP ${response.status}`);
+  }
+  return response.text();
+}
+
 Deno.serve(async req => {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
@@ -51,12 +106,35 @@ Deno.serve(async req => {
   }
 
   let html: string;
+  let sourceUrl = '';
+
   try {
     const body = await req.json();
-    html = body.html;
-    if (!html || typeof html !== 'string') {
+
+    if (body.html && typeof body.html === 'string') {
+      html = body.html;
+      if (body.url && typeof body.url === 'string') {
+        sourceUrl = body.url;
+      }
+    } else if (body.url && typeof body.url === 'string') {
+      // Server-side fetch — kept for backwards compatibility with share extension fallback
+      sourceUrl = body.url;
+      try {
+        html = await fetchHtmlFromUrl(sourceUrl);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        console.error('Failed to fetch URL:', message);
+        return new Response(
+          JSON.stringify({error: `Failed to fetch recipe page: ${message}`}),
+          {
+            status: 422,
+            headers: {...CORS_HEADERS, 'Content-Type': 'application/json'},
+          },
+        );
+      }
+    } else {
       return new Response(
-        JSON.stringify({error: "Missing or invalid 'html' field"}),
+        JSON.stringify({error: "Request body must include 'html' or 'url'"}),
         {
           status: 400,
           headers: {...CORS_HEADERS, 'Content-Type': 'application/json'},
@@ -70,6 +148,19 @@ Deno.serve(async req => {
     });
   }
 
+  // Fast path: JSON-LD extraction (no AI call needed)
+  const jsonld = extractJsonLd(html);
+  if (jsonld) {
+    const recipe = formatRecipeFromJsonLd(jsonld, sourceUrl);
+    if (recipe) {
+      return new Response(JSON.stringify(recipe), {
+        status: 200,
+        headers: {...CORS_HEADERS, 'Content-Type': 'application/json'},
+      });
+    }
+  }
+
+  // Fallback: Claude AI extraction
   const ANTHROPIC_API_KEY = Deno.env.get('ANTHROPIC_API_KEY');
   if (!ANTHROPIC_API_KEY) {
     return new Response(
@@ -166,13 +257,25 @@ Return ONLY the JSON object, no markdown, no explanation, no code fences.`;
       );
     }
 
-    // Ensure all expected fields exist with defaults
+    // Derive URL fields if a source URL was provided
+    let hostUrl = '';
+    let hostName = '';
+    if (sourceUrl) {
+      try {
+        const parsed = new URL(sourceUrl);
+        hostUrl = `${parsed.protocol}//${parsed.host}`;
+        hostName = parsed.hostname;
+      } catch {
+        // invalid URL — leave blank
+      }
+    }
+
     const result = {
       title: recipe.title || '',
       author: recipe.author || '',
-      original_url: '',
-      host_url: '',
-      host_name: '',
+      original_url: sourceUrl,
+      host_url: hostUrl,
+      host_name: hostName,
       categories: recipe.categories || '',
       image: recipe.image || '',
       ingredients: cleanIngredients(recipe.ingredients || ''),


### PR DESCRIPTION
                                                                                                                                 
# Add recipe import via URL paste                                                                                                         
                                                                                                                                          
  Replaces the "Open browser" option in the Add Recipe modal with an in-app URL paste flow. Users can now paste a recipe link directly    
  into the app and have it imported without leaving to Safari and using the share sheet.                                                  
                                                                                                                                        
## Changes                                                                                                                                 
                                                                                                                                        
### In-app URL import (AddModal.tsx)                                                                                                        
  - Swaps the "Open browser" button for "Paste a link", which transitions the modal to a URL input view
  - Client fetches the HTML on-device and sends it to the edge function alongside the URL, so the server can derive host metadata without 
  a second fetch                                                                                                                         
  - Modal state (showUrlInput, recipeUrl) resets on close or back navigation                                                              
  - Added avoidKeyboard to the modal so the input isn't obscured by the keyboard                                                        
                                                                                                                                          
### JSON-LD fast path (recipeUtils.ts, import-recipe/index.ts)                                                                              
  - Extracts and parses application/ld+json structured data from HTML before falling back to AI extraction, eliminating unnecessary       
  Anthropic API calls for the majority of well-structured recipe sites                                                                    
  - Handles the full range of JSON-LD shapes in the wild: top-level objects, @graph arrays, itemListElement wrappers, array @type fields,
  HowToSection instruction groupings                                                                                                      
  - Derives host_url and host_name from the source URL in both the fast path and the AI fallback path                                     
  - Edge function now also accepts { url } alone for server-side fetching (used by the share extension fallback)
                                                                                                                                          
### Security & correctness                                                                                                                  
  - Added assertPublicUrl validation before any server-side URL fetch to block SSRF vectors: non-http/https schemes, loopback, RFC-1918   
  ranges, and link-local addresses including the AWS metadata endpoint                                                                    
  - Fixed a time unit bug in the prep+cook fallback path where totals ≥ 60 minutes were stored with unit 'hr' without converting the      
  value, producing incorrect display (e.g. "90 hr" instead of "90 min")   