### PR TITLE
Structured ingredient display, paywall fix, and UX polish

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -38,9 +38,15 @@ const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
 
 // Store Supabase credentials in App Group for share extension
-async function storeSupabaseCredentials(session: Session): Promise<boolean> {
+async function storeSupabaseCredentials(session: Session): Promise<void> {
+  try {
+    await Purchases.logIn(session.user.id);
+  } catch (error) {
+    console.error('Failed to log in to RevenueCat:', error);
+  }
+
   if (Platform.OS !== 'ios' || !AppGroupStorage) {
-    return false;
+    return;
   }
 
   try {
@@ -56,8 +62,6 @@ async function storeSupabaseCredentials(session: Session): Promise<boolean> {
         session.access_token,
       );
       await AppGroupStorage.setItem('supabaseUserId', session.user.id);
-      const {customerInfo} = await Purchases.logIn(session.user.id);
-      const isPro = !!customerInfo.entitlements.active.pro;
 
       // Store API URL if provided
       if (recipeImportAPIURL) {
@@ -65,12 +69,10 @@ async function storeSupabaseCredentials(session: Session): Promise<boolean> {
       }
 
       console.log('Stored Supabase credentials in App Group');
-      return isPro;
     }
   } catch (error) {
     console.error('Failed to store Supabase credentials:', error);
   }
-  return false;
 }
 
 function AddComponent() {
@@ -308,13 +310,13 @@ export default function App({}: AppProps): React.JSX.Element {
       handleResetPasswordUrl(url);
     });
 
-    supabase.auth.getSession().then(({data: {session}}) => {
+    supabase.auth.getSession().then(async ({data: {session}}) => {
       setAuthSession(session);
-      setIsLoadingSession(false);
       if (session) {
-        // Store Supabase credentials and auth token in App Group for share extension
-        storeSupabaseCredentials(session);
+        // Link RevenueCat to the user before rendering so isPro is accurate on first render
+        await storeSupabaseCredentials(session);
       }
+      setIsLoadingSession(false);
     });
     const {
       data: {subscription},

--- a/src/components/GroceryListModal.tsx
+++ b/src/components/GroceryListModal.tsx
@@ -40,9 +40,7 @@ function toGroceryIngredients(rows: RecipeIngredient[]): Ingredient[] {
     id: row.id,
     name: row.base_name,
     amount:
-      row.quantity && row.unit
-        ? `${row.quantity} ${row.unit}`
-        : row.quantity || '',
+      row.amount && row.unit ? `${row.amount} ${row.unit}` : row.amount || '',
   }));
 }
 
@@ -58,6 +56,7 @@ export default function GroceryListModal() {
     new Set(),
   );
   const fadeAnim = useRef(new Animated.Value(0)).current;
+  const [shouldRender, setShouldRender] = useState(false);
 
   const parsedIngredients = useMemo(
     () => toGroceryIngredients(structuredIngredients),
@@ -199,6 +198,7 @@ export default function GroceryListModal() {
 
   useEffect(() => {
     if (visible) {
+      setShouldRender(true);
       Animated.timing(fadeAnim, {
         toValue: 1,
         duration: 150,
@@ -209,11 +209,15 @@ export default function GroceryListModal() {
         toValue: 0,
         duration: 150,
         useNativeDriver: true,
-      }).start();
+      }).start(({finished}) => {
+        if (finished) {
+          setShouldRender(false);
+        }
+      });
     }
   }, [visible, fadeAnim]);
 
-  if (!visible) {
+  if (!shouldRender) {
     return null;
   }
 

--- a/src/components/IngredientEditor.tsx
+++ b/src/components/IngredientEditor.tsx
@@ -8,46 +8,35 @@ import DraggableFlatList, {
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import {useTheme} from '../../theme/ThemeProvider';
 import {Theme} from '../../theme/types';
-import {parseIngredient} from '../services/unitService';
+import {RecipeIngredient} from '../models';
 
 type IngredientRow = {
   id: string;
   amount: string;
-  text: string;
+  name: string;
 };
 
-const parseRows = (ingredients: string): IngredientRow[] => {
-  if (!ingredients?.trim()) {
-    return [];
-  }
-  return ingredients
-    .split('\n')
-    .filter(l => l.trim())
-    .map((line, i) => {
-      const {quantity, unit, text} = parseIngredient(line);
-      return {
-        id: String(i),
-        amount: [quantity, unit].filter(Boolean).join(' '),
-        text,
-      };
-    });
-};
-
-const serializeRows = (rows: IngredientRow[]): string =>
-  rows.map(r => [r.amount, r.text].filter(Boolean).join(' ')).join('\n');
+const fromRecipeIngredients = (
+  ingredients: RecipeIngredient[],
+): IngredientRow[] =>
+  ingredients.map(r => ({
+    id: r.id,
+    amount: [r.amount, r.unit].filter(Boolean).join(' '),
+    name: r.name,
+  }));
 
 export default function IngredientEditor({
   ingredients,
   onChange,
   scrollViewRef,
 }: {
-  ingredients: string;
-  onChange: (value: string) => void;
+  ingredients: RecipeIngredient[];
+  onChange: (rows: IngredientRow[]) => void;
   scrollViewRef?: React.RefObject<ScrollView>;
 }) {
   const theme = useTheme() as unknown as Theme;
 
-  const initialRows = parseRows(ingredients);
+  const initialRows = fromRecipeIngredients(ingredients);
   const [rows, setRows] = useState<IngredientRow[]>(initialRows);
   const nextId = useRef(initialRows.length);
   const amountRefs = useRef<Map<string, TextInput | null>>(new Map());
@@ -56,7 +45,7 @@ export default function IngredientEditor({
   const commit = useCallback(
     (newRows: IngredientRow[]) => {
       setRows(newRows);
-      onChange(serializeRows(newRows));
+      onChange(newRows);
     },
     [onChange],
   );
@@ -79,14 +68,14 @@ export default function IngredientEditor({
 
   const addRow = useCallback(() => {
     const id = String(Date.now()) + String(nextId.current++);
-    const newRows = [...rows, {id, amount: '', text: ''}];
+    const newRows = [...rows, {id, amount: '', name: ''}];
     commit(newRows);
     // Defer focus until after the new row has mounted
     setTimeout(() => amountRefs.current.get(id)?.focus(), 50);
   }, [rows, commit]);
 
   const focusNext = useCallback(
-    (id: string, field: 'amount' | 'text') => {
+    (id: string, field: 'amount' | 'name') => {
       if (field === 'amount') {
         textRefs.current.get(id)?.focus();
       } else {
@@ -104,6 +93,7 @@ export default function IngredientEditor({
   const renderItem = useCallback(
     ({item, drag, isActive, getIndex}: RenderItemParams<IngredientRow>) => {
       const isLast = (getIndex() ?? 0) === rows.length - 1;
+      const isRaw = item.id.startsWith('raw-');
       return (
         <ScaleDecorator>
           <View
@@ -122,29 +112,33 @@ export default function IngredientEditor({
                 color={theme.colors['neutral-300']}
               />
             </TouchableOpacity>
-            <TextInput
-              ref={ref => amountRefs.current.set(item.id, ref)}
-              style={styles(theme).amountInput}
-              value={item.amount}
-              placeholder="Amount"
-              placeholderTextColor={theme.colors['neutral-300']}
-              onChangeText={v => updateField(item.id, 'amount', v)}
-              returnKeyType="next"
-              onSubmitEditing={() => focusNext(item.id, 'amount')}
-              blurOnSubmit={false}
-            />
-            <View style={styles(theme).separator} />
+            {!isRaw && (
+              <>
+                <TextInput
+                  ref={ref => amountRefs.current.set(item.id, ref)}
+                  style={styles(theme).amountInput}
+                  value={item.amount}
+                  placeholder="Amount"
+                  placeholderTextColor={theme.colors['neutral-300']}
+                  onChangeText={v => updateField(item.id, 'amount', v)}
+                  returnKeyType="next"
+                  onSubmitEditing={() => focusNext(item.id, 'amount')}
+                  blurOnSubmit={false}
+                />
+                <View style={styles(theme).separator} />
+              </>
+            )}
             <TextInput
               ref={ref => textRefs.current.set(item.id, ref)}
               style={styles(theme).nameInput}
-              value={item.text}
+              value={item.name}
               placeholder="Ingredient"
               placeholderTextColor={theme.colors['neutral-300']}
               onChangeText={v => {
                 if (v.includes('\n')) {
-                  focusNext(item.id, 'text');
+                  focusNext(item.id, 'name');
                 } else {
-                  updateField(item.id, 'text', v);
+                  updateField(item.id, 'name', v);
                 }
               }}
               multiline

--- a/src/components/RecipeDetailsScreen.tsx
+++ b/src/components/RecipeDetailsScreen.tsx
@@ -18,19 +18,37 @@ import DetailsMenuHeader from './DetailsMenuHeader';
 import {recipeService} from '../services';
 import {RecipeIngredient} from '../models';
 
+const withIngredientRows = (item: any) => {
+  if (item.ingredientRows?.length || !item.ingredients) {
+    return {...item};
+  }
+  const ingredientRows = item.ingredients
+    .split('\n')
+    .filter((l: string) => l.trim())
+    .map((line: string, i: number) => ({
+      id: `import-${i}`,
+      amount: '',
+      name: line.trim(),
+    }));
+  return {...item, ingredientRows};
+};
+
 export default function RecipeDetailsScreen({route, navigation}: any) {
   const viewMode = useAppSelector(state => state.viewMode.value);
   const {setHandleSavePress, setHandleDeletePress} = useEditingHandler();
   const [data, onChangeData] = useState({...route.params.item});
   const [isLoading, setIsLoading] = useState(false);
-  const [editingData, onChangeEditingData] = useState({...route.params.item});
+  const [editingData, onChangeEditingData] = useState(
+    withIngredientRows({...route.params.item}),
+  );
   const [showSavedMessage, setShowSavedMessage] = useState(false);
   const [structuredIngredients, setStructuredIngredients] = useState<
     RecipeIngredient[]
   >([]);
+  const [isLoadingIngredients, setIsLoadingIngredients] = useState(!!data.id);
   const autoSaveTriggeredRef = useRef(false);
-  const fadeAnim = useState(new Animated.Value(0))[0];
-  const scaleAnim = useState(new Animated.Value(0.8))[0];
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const scaleAnim = useRef(new Animated.Value(0.8)).current;
   const theme = useTheme() as unknown as Theme;
 
   const showSavedMessageTemporarily = useCallback(() => {
@@ -70,16 +88,29 @@ export default function RecipeDetailsScreen({route, navigation}: any) {
     });
   }, [fadeAnim, scaleAnim]);
 
-  const loadStructuredIngredients = useCallback(async (recipeId: string) => {
+  const loadRecipeData = useCallback(async (recipeId: string) => {
+    try {
+      const {recipe, ingredients} =
+        await recipeService.fetchRecipeWithIngredients(recipeId);
+      onChangeData(recipe);
+      setStructuredIngredients(ingredients);
+    } catch (e: any) {
+      console.error('Failed to load recipe data:', e.message);
+    } finally {
+      setIsLoadingIngredients(false);
+    }
+  }, []);
+
+  const refreshIngredients = useCallback(async (recipeId: string) => {
     const rows = await recipeService.fetchRecipeIngredients(recipeId);
     setStructuredIngredients(rows);
   }, []);
 
   useEffect(() => {
     if (data.id) {
-      loadStructuredIngredients(data.id);
+      loadRecipeData(data.id);
     }
-  }, [data.id, loadStructuredIngredients]);
+  }, [data.id, loadRecipeData]);
 
   const handleSavePress = useCallback(async () => {
     setIsLoading(true);
@@ -94,14 +125,14 @@ export default function RecipeDetailsScreen({route, navigation}: any) {
       showSavedMessageTemporarily();
 
       if (savedRecipe.id) {
-        await loadStructuredIngredients(savedRecipe.id);
+        await refreshIngredients(savedRecipe.id);
       }
     } catch (e: any) {
       Alert.alert('Error', e.message || 'Failed to save recipe');
     } finally {
       setIsLoading(false);
     }
-  }, [editingData, showSavedMessageTemporarily, loadStructuredIngredients]);
+  }, [editingData, showSavedMessageTemporarily, refreshIngredients]);
 
   const handleDeletePress = useCallback(async () => {
     setIsLoading(true);
@@ -193,12 +224,14 @@ export default function RecipeDetailsScreen({route, navigation}: any) {
         <RecipeViewer
           data={data}
           structuredIngredients={structuredIngredients}
+          isLoadingIngredients={isLoadingIngredients}
         />
       )}
       {viewMode !== 'view' && (
         <RecipeEditor
           editingData={editingData}
           onChangeEditingData={handleChangeEditData}
+          structuredIngredients={structuredIngredients}
         />
       )}
       {isLoading && (
@@ -206,17 +239,16 @@ export default function RecipeDetailsScreen({route, navigation}: any) {
           <ActivityIndicator size="large" color={theme.colors.subtext} />
         </View>
       )}
-      {showSavedMessage && (
-        <Animated.View
-          style={[
-            styles(theme).savedMessageContainer,
-            {opacity: fadeAnim, transform: [{scale: scaleAnim}]},
-          ]}>
-          <View style={styles(theme).saveMessageBackground}>
-            <Text style={styles(theme).savedMessageText}>Recipe Saved!</Text>
-          </View>
-        </Animated.View>
-      )}
+      <Animated.View
+        pointerEvents={showSavedMessage ? 'box-none' : 'none'}
+        style={[
+          styles(theme).savedMessageContainer,
+          {opacity: fadeAnim, transform: [{scale: scaleAnim}]},
+        ]}>
+        <View style={styles(theme).saveMessageBackground}>
+          <Text style={styles(theme).savedMessageText}>Recipe Saved!</Text>
+        </View>
+      </Animated.View>
       <GroceryListModal />
     </View>
   );
@@ -250,13 +282,13 @@ const styles = (theme: any) =>
       height: '100%',
     },
     saveMessageBackground: {
-      backgroundColor: theme.colors.opaque,
+      backgroundColor: theme.colors['neutral-300'],
       borderRadius: 16,
     },
     savedMessageText: {
-      paddingHorizontal: 20,
-      paddingVertical: 40,
-      color: 'white',
-      fontSize: 16,
+      paddingHorizontal: 24,
+      paddingVertical: 16,
+      ...theme.typography['h2-emphasized'],
+      color: theme.colors['neutral-800'],
     },
   });

--- a/src/components/RecipeEditor.tsx
+++ b/src/components/RecipeEditor.tsx
@@ -27,8 +27,36 @@ import {useTheme} from '../../theme/ThemeProvider';
 import {Theme} from '../../theme/types';
 import {useHeaderHeight} from '@react-navigation/elements';
 import {supabase} from '../supabase-client';
+import {RecipeIngredient} from '../models';
 
-export default function RecipeEditor({editingData, onChangeEditingData}: any) {
+const rawToRecipeIngredients = (raw: string): RecipeIngredient[] => {
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean)
+    .map((line, i) => ({
+      id: `raw-${i}`,
+      recipe_id: 0,
+      name: line,
+      base_name: '',
+      amount: null,
+      unit: null,
+      sort_order: i,
+    }));
+};
+
+export default function RecipeEditor({
+  editingData,
+  onChangeEditingData,
+  structuredIngredients,
+}: {
+  editingData: any;
+  onChangeEditingData: any;
+  structuredIngredients: RecipeIngredient[];
+}) {
   const [modalVisible, setModalVisible] = useState(false);
   const [totalTimeModalVisible, setTotalTimeModalVisible] = useState(false);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
@@ -172,6 +200,14 @@ export default function RecipeEditor({editingData, onChangeEditingData}: any) {
         ? editingData.categories.split(',').filter((cat: string) => cat.trim())
         : [],
     [editingData.categories],
+  );
+
+  const effectiveIngredients = useMemo(
+    () =>
+      structuredIngredients.length > 0
+        ? structuredIngredients
+        : rawToRecipeIngredients(editingData.ingredients || ''),
+    [structuredIngredients, editingData.ingredients],
   );
 
   const tablet = isTablet();
@@ -327,11 +363,11 @@ export default function RecipeEditor({editingData, onChangeEditingData}: any) {
               />
             </View>
             <IngredientEditor
-              ingredients={editingData.ingredients}
-              onChange={(value: string) =>
+              ingredients={effectiveIngredients}
+              onChange={rows =>
                 onChangeEditingData((prev: any) => ({
                   ...prev,
-                  ingredients: value,
+                  ingredientRows: rows,
                 }))
               }
               scrollViewRef={scrollViewRef}

--- a/src/components/RecipeViewer.tsx
+++ b/src/components/RecipeViewer.tsx
@@ -13,48 +13,81 @@ import {useTheme} from '../../theme/ThemeProvider';
 import {Theme} from '../../theme/types';
 import {useHeaderHeight} from '@react-navigation/elements';
 import CustomToggle from './CustomToggle';
-import {parseIngredient, scaleIngredients} from '../services';
+import {scaleQuantity} from '../services';
 import {useGroceryListModal} from '../context/GroceryListModalContext';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import BraiseLogoLight from '../assets/images/braise-logo-light.svg';
 import {RecipeIngredient} from '../models';
 
+const parseAmountNum = (amount: string | null): number => {
+  if (!amount) {
+    return 0;
+  }
+  if (amount.includes('/')) {
+    const [n, d] = amount.split('/');
+    return parseFloat(n) / parseFloat(d);
+  }
+  return parseFloat(amount) || 0;
+};
+
+const pluralizeUnit = (
+  unit: string | null,
+  amount: string | null,
+): string | null => {
+  if (!unit) {
+    return null;
+  }
+  const num = parseAmountNum(amount);
+  if (num <= 1) {
+    return unit;
+  }
+  const noPlural = new Set([
+    'tsp',
+    'tbsp',
+    'oz',
+    'fl oz',
+    'g',
+    'kg',
+    'ml',
+    'l',
+  ]);
+  if (noPlural.has(unit.toLowerCase()) || unit.endsWith('s')) {
+    return unit;
+  }
+  return unit + 's';
+};
+
 export default function RecipeViewer({
   data,
   structuredIngredients = [],
+  isLoadingIngredients = false,
 }: {
   data: any;
   structuredIngredients?: RecipeIngredient[];
+  isLoadingIngredients?: boolean;
 }) {
   const theme = useTheme() as unknown as Theme;
   const {showModal} = useGroceryListModal();
   const [tab, setTab] = useState('ingredients');
   const [currentServings, setCurrentServings] = useState(data.servings || '-');
-  const [scaledIngredients, setScaledIngredients] = useState(
-    data.ingredients || '',
-  );
 
-  const updateServings = (newServings: string) => {
-    const newScaledIngredients = scaleIngredients(
-      data.ingredients || '',
-      newServings,
-      data.servings != null ? data.servings.toString() : '1',
-    );
-
-    setCurrentServings(newServings);
-    setScaledIngredients(newScaledIngredients);
-  };
+  const originalServings =
+    data.servings != null ? parseFloat(data.servings.toString()) : 1;
+  const scaleFactor =
+    currentServings !== '-'
+      ? parseFloat(currentServings) / originalServings
+      : 1;
 
   const handleDecreaseServings = () => {
     const num = parseInt(currentServings, 10) || 1;
     if (num > 1) {
-      updateServings(String(num - 1));
+      setCurrentServings(String(num - 1));
     }
   };
 
   const handleIncreaseServings = () => {
     const num = parseInt(currentServings, 10) || 1;
-    updateServings(String(num + 1));
+    setCurrentServings(String(num + 1));
   };
 
   const onAddToShoppingListPress = () => {
@@ -62,32 +95,6 @@ export default function RecipeViewer({
       data?.id && data?.title ? {id: data.id, title: data.title} : undefined;
     showModal(structuredIngredients, recipeInfo);
   };
-
-  useEffect(() => {
-    if (data.ingredients) {
-      const originalServings =
-        data.servings != null && data.servings !== '-'
-          ? data.servings.toString()
-          : '1';
-      const servings =
-        currentServings &&
-        currentServings !== '-' &&
-        currentServings !== originalServings
-          ? currentServings
-          : originalServings;
-
-      if (servings !== originalServings) {
-        const newScaledIngredients = scaleIngredients(
-          data.ingredients,
-          servings,
-          originalServings,
-        );
-        setScaledIngredients(newScaledIngredients);
-      } else {
-        setScaledIngredients(data.ingredients);
-      }
-    }
-  }, [data.ingredients, data.servings, currentServings]);
 
   useEffect(() => {
     // Only update currentServings if data.servings changes to a non-null value
@@ -189,36 +196,42 @@ export default function RecipeViewer({
             </View>
             {tab === 'ingredients' && (
               <View style={styles(theme).ingredientsContainer}>
-                {scaledIngredients ? (
-                  scaledIngredients
-                    .split('\n')
-                    .map((ingredient: string, index: number, arr: string[]) => {
-                      const {quantity, unit, text} =
-                        parseIngredient(ingredient);
-                      return (
-                        <View
-                          style={[
-                            styles(theme).ingredientLine,
-                            index !== arr.length - 1 &&
-                              styles(theme).ingredientDivider,
-                          ]}
-                          key={index}>
-                          <View style={styles(theme).quantityContainer}>
-                            {quantity ? (
-                              <Text style={styles(theme).quantity}>
-                                {quantity} {unit}
-                              </Text>
-                            ) : (
-                              <View style={styles(theme).emptyQuantity} />
-                            )}
-                          </View>
+                {structuredIngredients.length > 0 ? (
+                  structuredIngredients.map((row, index) => {
+                    const scaledAmount =
+                      scaleFactor !== 1 && row.amount
+                        ? scaleQuantity(row.amount, scaleFactor)
+                        : row.amount;
+                    const displayUnit = pluralizeUnit(row.unit, scaledAmount);
+                    const amountDisplay = [scaledAmount, displayUnit]
+                      .filter(Boolean)
+                      .join(' ');
+                    return (
+                      <View
+                        style={[
+                          styles(theme).ingredientLine,
+                          index !== structuredIngredients.length - 1 &&
+                            styles(theme).ingredientDivider,
+                        ]}
+                        key={row.id}>
+                        <View style={styles(theme).quantityContainer}>
+                          {amountDisplay ? (
+                            <Text style={styles(theme).quantity}>
+                              {amountDisplay}
+                            </Text>
+                          ) : (
+                            <View style={styles(theme).emptyQuantity} />
+                          )}
+                        </View>
+                        <View style={styles(theme).ingredientNameContainer}>
                           <Text style={styles(theme).ingredientText}>
-                            {text}
+                            {row.name}
                           </Text>
                         </View>
-                      );
-                    })
-                ) : (
+                      </View>
+                    );
+                  })
+                ) : isLoadingIngredients ? null : (
                   <View style={styles(theme).emptyStateContainer}>
                     <Text style={styles(theme).emptyStateText}>
                       No ingredients found. Add them in edit mode or view the
@@ -257,22 +270,24 @@ export default function RecipeViewer({
                 </View>
               </>
             )}
-            <Pressable
-              style={({pressed}) => [
-                styles(theme).addToShoppingListButton,
-                pressed && {backgroundColor: theme.colors['yellow-400']},
-              ]}
-              onPress={onAddToShoppingListPress}>
-              <Ionicons
-                name="list-outline"
-                size={20}
-                color={theme.colors['neutral-100']}
-                style={styles(theme).addToShoppingListIcon}
-              />
-              <Text style={styles(theme).addToShoppingListText}>
-                Add to grocery list
-              </Text>
-            </Pressable>
+            {!isLoadingIngredients && (
+              <Pressable
+                style={({pressed}) => [
+                  styles(theme).addToShoppingListButton,
+                  pressed && {backgroundColor: theme.colors['yellow-400']},
+                ]}
+                onPress={onAddToShoppingListPress}>
+                <Ionicons
+                  name="list-outline"
+                  size={20}
+                  color={theme.colors['neutral-100']}
+                  style={styles(theme).addToShoppingListIcon}
+                />
+                <Text style={styles(theme).addToShoppingListText}>
+                  Add to grocery list
+                </Text>
+              </Pressable>
+            )}
           </View>
         </View>
       </ScrollView>
@@ -354,7 +369,7 @@ const styles = (theme: any) =>
       borderBottomColor: theme.colors['neutral-300'],
     },
     quantityContainer: {
-      width: 80,
+      flex: 1,
       alignItems: 'flex-end',
       paddingRight: 15,
     },
@@ -367,12 +382,12 @@ const styles = (theme: any) =>
       width: 1,
       height: 24,
     },
+    ingredientNameContainer: {
+      flex: 2,
+    },
     ingredientText: {
       ...theme.typography.b1,
-      flex: 1,
       color: theme.colors['neutral-800'],
-      textAlign: 'left',
-      marginLeft: 0,
     },
     lineContainer: {
       flex: 1,

--- a/src/components/ServingsPickerModal.tsx
+++ b/src/components/ServingsPickerModal.tsx
@@ -29,6 +29,7 @@ export default function ServingsPickerModal({
   const theme = useTheme() as unknown as Theme;
   const [selectedServings, setSelectedServings] = useState(currentValue || '-');
   const fadeAnim = useRef(new Animated.Value(0)).current;
+  const [modalVisible, setModalVisible] = useState(visible);
 
   const servingsOptions = [
     '-',
@@ -38,6 +39,7 @@ export default function ServingsPickerModal({
 
   useEffect(() => {
     if (visible) {
+      setModalVisible(true);
       Animated.timing(fadeAnim, {
         toValue: 1,
         duration: 150,
@@ -48,7 +50,11 @@ export default function ServingsPickerModal({
         toValue: 0,
         duration: 150,
         useNativeDriver: true,
-      }).start();
+      }).start(({finished}) => {
+        if (finished) {
+          setModalVisible(false);
+        }
+      });
     }
   }, [visible, fadeAnim]);
 
@@ -59,7 +65,7 @@ export default function ServingsPickerModal({
 
   return (
     <Modal
-      visible={visible}
+      visible={modalVisible}
       transparent={true}
       animationType="none"
       onRequestClose={onClose}>

--- a/src/components/TotalTimePickerModal.tsx
+++ b/src/components/TotalTimePickerModal.tsx
@@ -32,6 +32,7 @@ export default function TotalTimePickerModal({
   const [selectedTime, setSelectedTime] = useState(currentTime || '-');
   const [selectedUnit, setSelectedUnit] = useState(currentUnit || '-');
   const fadeAnim = useRef(new Animated.Value(0)).current;
+  const [modalVisible, setModalVisible] = useState(visible);
 
   const timeOptions = [
     '-',
@@ -41,6 +42,7 @@ export default function TotalTimePickerModal({
 
   useEffect(() => {
     if (visible) {
+      setModalVisible(true);
       Animated.timing(fadeAnim, {
         toValue: 1,
         duration: 150,
@@ -51,7 +53,11 @@ export default function TotalTimePickerModal({
         toValue: 0,
         duration: 150,
         useNativeDriver: true,
-      }).start();
+      }).start(({finished}) => {
+        if (finished) {
+          setModalVisible(false);
+        }
+      });
     }
   }, [visible, fadeAnim]);
 
@@ -62,7 +68,7 @@ export default function TotalTimePickerModal({
 
   return (
     <Modal
-      visible={visible}
+      visible={modalVisible}
       transparent={true}
       animationType="none"
       onRequestClose={onClose}>

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -21,10 +21,9 @@ export interface Recipe {
 export interface RecipeIngredient {
   id: string;
   recipe_id: number;
-  display_text: string;
+  name: string;
   base_name: string;
-  prep: string | null;
-  quantity: string | null;
+  amount: string | null;
   unit: string | null;
   sort_order: number;
   created_at?: string;

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -13,9 +13,10 @@ const processNewlines = (recipe: any) => {
 };
 
 const processForSave = (recipe: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const {ingredientRows: _ingredientRows, ...rest} = recipe;
   return {
-    ...recipe,
-    ingredients: recipe.ingredients?.replace(/\\n$/, ''),
+    ...rest,
     total_time: recipe.total_time ? parseInt(recipe.total_time, 10) : null,
     servings: recipe.servings ? parseInt(recipe.servings, 10) : null,
   };
@@ -23,11 +24,10 @@ const processForSave = (recipe: any) => {
 
 const structureRecipeIngredients = async (
   recipeId: string,
-  ingredientsString: string,
+  rows: {amount: string; name: string}[],
 ): Promise<void> => {
-  const lines = (ingredientsString || '')
-    .split('\n')
-    .map((l: string) => l.trim())
+  const lines = rows
+    .map(r => [r.amount, r.name].filter(Boolean).join(' '))
     .filter(Boolean);
 
   try {
@@ -100,7 +100,7 @@ export const recipeService = {
 
       await structureRecipeIngredients(
         String(processedRecipe.id),
-        processedRecipe.ingredients || '',
+        recipe.ingredientRows || [],
       );
 
       return processedRecipe;
@@ -142,10 +142,12 @@ export const recipeService = {
       );
       await Storage.saveRecipesToLocal(updatedRecipes);
 
-      await structureRecipeIngredients(
-        String(processedRecipe.id),
-        processedRecipe.ingredients || '',
-      );
+      if (recipe.ingredientRows !== undefined) {
+        await structureRecipeIngredients(
+          String(processedRecipe.id),
+          recipe.ingredientRows,
+        );
+      }
 
       return processedRecipe;
     } catch (error: any) {
@@ -173,6 +175,32 @@ export const recipeService = {
     } catch (error: any) {
       console.error('Failed to update viewed_at:', error.message);
     }
+  },
+
+  async fetchRecipeWithIngredients(
+    recipeId: string,
+  ): Promise<{recipe: any; ingredients: RecipeIngredient[]}> {
+    const {data, error} = await supabase
+      .from('recipes')
+      .select(
+        '*, recipe_ingredients(id, name, base_name, amount, unit, sort_order)',
+      )
+      .eq('id', recipeId)
+      .order('sort_order', {
+        ascending: true,
+        referencedTable: 'recipe_ingredients',
+      })
+      .single();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const {recipe_ingredients, ...recipe} = data;
+    return {
+      recipe: processNewlines(recipe),
+      ingredients: recipe_ingredients || [],
+    };
   },
 
   async fetchRecipeIngredients(recipeId: string): Promise<RecipeIngredient[]> {

--- a/supabase/functions/_shared/recipeUtils.ts
+++ b/supabase/functions/_shared/recipeUtils.ts
@@ -420,10 +420,9 @@ export type ClaudeCallResult =
   | {ok: false; status: 502; error: string};
 
 export interface StructuredIngredient {
-  display_text: string;
+  name: string;
   base_name: string;
-  prep: string | null;
-  quantity: string | null;
+  amount: string | null;
   unit: string | null;
 }
 
@@ -434,22 +433,16 @@ export type StructureIngredientsResult =
 const STRUCTURING_SYSTEM_PROMPT = `You are an ingredient structuring assistant. Given a JSON array of recipe ingredient lines, parse each line into structured fields.
 
 Return ONLY a JSON array of objects with these exact fields:
-- "display_text": string (the original ingredient line, preserved exactly)
-- "base_name": string (the purchasable product name a person would look for at a grocery store)
-- "prep": string or null (home preparation instruction — e.g. "diced", "minced", "sliced", "cubed"; null if none)
-- "quantity": string or null (the numeric quantity as a string, e.g. "2", "1/2", "3/4"; null if none)
-- "unit": string or null (the unit of measurement, e.g. "cup", "tsp", "lb", "clove"; null if none)
-
-Rules for base_name vs prep:
-- base_name: the name of the product as sold at a grocery store
-- prep: home preparation instructions (dice, chop, mince, slice, cube, cut, torn, chopped)
-- Packaging-form words (shredded, ground, powdered, crushed, dried, smoked, roasted) stay IN base_name because they describe how the product is manufactured or sold (e.g. "shredded cheese", "ground beef", "dried oregano", "powdered sugar", "crushed tomatoes")
+- "name": string (the ingredient description without the leading quantity and unit — keep all other text exactly as written, including prep instructions, qualifiers, and packaging descriptors; e.g. "garlic, minced", "salt to taste", "shredded parmesan", "potatoes, cut into cubes")
+- "base_name": string (the core purchasable product a person would search for at a grocery store — strip prep instructions and qualifiers like "to taste" or "for garnish", but keep packaging-form words that describe how the product is sold, e.g. "shredded parmesan", "ground beef", "dried oregano")
+- "amount": string or null (the numeric quantity as a string, e.g. "2", "1/2", "3/4"; null if none)
+- "unit": string or null (abbreviated unit of measurement, always singular, e.g. "tsp", "tbsp", "cup", "oz", "lb", "g", "ml", "clove", "can", "bunch", "pinch", "dash"; null if none)
 
 CRITICAL: Output array must have exactly the same number of elements as the input array, in the same order. Do not split, merge, skip, or reorder lines.
 
 Examples (given as input array → output array):
-Input: ["2 cups tomatoes, diced","1 tsp red pepper flakes","1 lb ground beef","3 potatoes, cut into cubes","1 cup shredded parmesan","2 cloves garlic, minced"]
-Output: [{"display_text":"2 cups tomatoes, diced","base_name":"tomatoes","prep":"diced","quantity":"2","unit":"cup"},{"display_text":"1 tsp red pepper flakes","base_name":"red pepper flakes","prep":null,"quantity":"1","unit":"tsp"},{"display_text":"1 lb ground beef","base_name":"ground beef","prep":null,"quantity":"1","unit":"lb"},{"display_text":"3 potatoes, cut into cubes","base_name":"potatoes","prep":"cubed","quantity":"3","unit":null},{"display_text":"1 cup shredded parmesan","base_name":"shredded parmesan","prep":null,"quantity":"1","unit":"cup"},{"display_text":"2 cloves garlic, minced","base_name":"garlic","prep":"minced","quantity":"2","unit":"clove"}]
+Input: ["2 cups tomatoes, diced","1 tsp red pepper flakes","1 lb ground beef","3 potatoes, cut into cubes","1 cup shredded parmesan","2 cloves garlic, minced","salt to taste"]
+Output: [{"name":"tomatoes, diced","base_name":"tomatoes","amount":"2","unit":"cup"},{"name":"red pepper flakes","base_name":"red pepper flakes","amount":"1","unit":"tsp"},{"name":"ground beef","base_name":"ground beef","amount":"1","unit":"lb"},{"name":"potatoes, cut into cubes","base_name":"potatoes","amount":"3","unit":null},{"name":"shredded parmesan","base_name":"shredded parmesan","amount":"1","unit":"cup"},{"name":"garlic, minced","base_name":"garlic","amount":"2","unit":"clove"},{"name":"salt to taste","base_name":"salt","amount":null,"unit":null}]
 
 Return ONLY the JSON array, no markdown, no explanation, no code fences.`;
 

--- a/supabase/functions/backfill-recipe-ingredients/index.ts
+++ b/supabase/functions/backfill-recipe-ingredients/index.ts
@@ -52,27 +52,6 @@ Deno.serve(async req => {
       auth: {autoRefreshToken: false, persistSession: false},
     });
 
-    const {data: structured, error: structuredError} = await adminClient
-      .from('recipe_ingredients')
-      .select('recipe_id');
-
-    if (structuredError) {
-      return new Response(
-        JSON.stringify({
-          error: 'fetch structured failed',
-          detail: structuredError.message,
-        }),
-        {
-          status: 500,
-          headers: {...CORS_HEADERS, 'Content-Type': 'application/json'},
-        },
-      );
-    }
-
-    const structuredIds = new Set(
-      (structured || []).map((r: {recipe_id: number}) => r.recipe_id),
-    );
-
     const {data: allRecipes, error: fetchError} = await adminClient
       .from('recipes')
       .select('id, ingredients');
@@ -90,18 +69,14 @@ Deno.serve(async req => {
       );
     }
 
-    const recipes = (allRecipes || []).filter(
-      (r: {id: number}) => !structuredIds.has(r.id),
-    );
-
     const results = {
-      total: recipes.length,
+      total: (allRecipes || []).length,
       succeeded: 0,
       failed: 0,
       failures: [] as {recipe_id: number; error: string}[],
     };
 
-    for (const recipe of recipes) {
+    for (const recipe of allRecipes || []) {
       if (!recipe.ingredients?.trim()) {
         results.succeeded++;
         continue;
@@ -140,13 +115,27 @@ Deno.serve(async req => {
 
       const rows = structureResult.data.map((item, i) => ({
         recipe_id: recipe.id,
-        display_text: item.display_text,
+        name: item.name,
         base_name: item.base_name,
-        prep: item.prep ?? null,
-        quantity: item.quantity ?? null,
+        amount: item.amount ?? null,
         unit: item.unit ?? null,
         sort_order: i,
       }));
+
+      // Delete existing rows before inserting updated ones
+      const {error: deleteError} = await adminClient
+        .from('recipe_ingredients')
+        .delete()
+        .eq('recipe_id', recipe.id);
+
+      if (deleteError) {
+        results.failed++;
+        results.failures.push({
+          recipe_id: recipe.id,
+          error: deleteError.message,
+        });
+        continue;
+      }
 
       const {error: insertError} = await adminClient
         .from('recipe_ingredients')

--- a/supabase/functions/structure-ingredients/index.ts
+++ b/supabase/functions/structure-ingredients/index.ts
@@ -131,10 +131,9 @@ Deno.serve(async req => {
 
   const rows = result.data.map((item, i) => ({
     recipe_id,
-    display_text: item.display_text,
+    name: item.name,
     base_name: item.base_name,
-    prep: item.prep ?? null,
-    quantity: item.quantity ?? null,
+    amount: item.amount ?? null,
     unit: item.unit ?? null,
     sort_order: i,
   }));

--- a/supabase/migrations/20260712_recipe_ingredients_refactor.sql
+++ b/supabase/migrations/20260712_recipe_ingredients_refactor.sql
@@ -1,0 +1,23 @@
+-- Refactor recipe_ingredients to {amount, unit, name, base_name} schema
+-- - rename quantity → amount
+-- - add name (ingredient description without amount/unit, e.g. "garlic, minced")
+-- - drop display_text and prep (display_text was the full original line; name replaces it
+--   scoped to just the ingredient description; prep is folded into name)
+--
+-- name is populated from existing data before display_text and prep are dropped so
+-- there is no window where rows have a null name. The LLM backfill then replaces
+-- these interim values with properly structured ones.
+-- After the backfill runs, apply 20260712_recipe_ingredients_name_not_null.sql.
+
+alter table public.recipe_ingredients rename column quantity to amount;
+
+alter table public.recipe_ingredients add column name text;
+
+-- Populate name from existing columns before dropping them.
+-- Reconstructs "garlic, minced" from base_name + prep as a safe interim value.
+-- The backfill edge function will replace these with LLM-structured values.
+update public.recipe_ingredients
+set name = base_name || coalesce(', ' || prep, '');
+
+alter table public.recipe_ingredients drop column display_text;
+alter table public.recipe_ingredients drop column prep;

--- a/supabase/migrations/20260713_recipe_ingredients_name_not_null.sql
+++ b/supabase/migrations/20260713_recipe_ingredients_name_not_null.sql
@@ -1,0 +1,5 @@
+-- Add NOT NULL constraint to recipe_ingredients.name after the LLM backfill
+-- has populated all rows. Run this only after confirming the backfill completed
+-- with zero failures.
+
+alter table public.recipe_ingredients alter column name set not null;


### PR DESCRIPTION
## Summary

- **Structured ingredient viewer**: RecipeViewer now displays `recipe_ingredients` rows (name, amount, unit) with a 1/3–2/3 quantity/name column split and per-serving scaling. A combined `fetchRecipeWithIngredients` query eliminates the two-round-trip load stagger; the grocery list button is hidden while ingredients are loading.
- **IngredientEditor fallback**: Raw (unstructured) ingredient lines show as single-column in the editor before a recipe is saved and structured by the edge function.
- **Paywall fix**: `Purchases.logIn` moved outside the `AppGroupStorage` guard so subscribers are correctly identified on launch.
- **Animated warning fix**: Modal components (`GroceryListModal`, `ServingsPickerModal`, `TotalTimePickerModal`) now defer unmount until their fade-out animation completes, eliminating the `onAnimatedValueUpdate` warning.
- **Edge function fix**: Simplified the `structure-ingredients` prompt unit description, which was causing the full ingredient line to be returned in the `name` field with null `amount`/`unit`.
- **Backfill**: Deployed `backfill-recipe-ingredients` and re-structured all 36 existing recipes with the corrected prompt.
- **DB migrations**: `recipe_ingredients` schema refactor (`quantity` → `amount`, add `name`, drop `display_text`/`prep`) and `name NOT NULL` constraint — both applied to production.

## Test plan

- [ ] Open an existing recipe — ingredients should load without a visible stagger or layout shift
- [ ] Adjust serving size in viewer — ingredient quantities should scale correctly
- [ ] Tap "Add to grocery list" — button should only appear after ingredients have loaded
- [ ] Import a new recipe and view before saving — ingredients should show as single-column lines in the editor
- [ ] Save an imported recipe — editor should switch to structured two-column display after save
- [ ] Log in as a subscriber — paywall should not appear
- [ ] Open and close the grocery list modal — no `onAnimatedValueUpdate` warning in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)