### PR TITLE
Bump build number to 1.1 (1)

### DIFF
--- a/ios/braise.xcodeproj/project.pbxproj
+++ b/ios/braise.xcodeproj/project.pbxproj
@@ -637,7 +637,7 @@
 				CODE_SIGN_ENTITLEMENTS = braise/braise.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 5HK264ADU8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = braise/Info.plist;
@@ -674,7 +674,7 @@
 				CODE_SIGN_ENTITLEMENTS = braise/braise.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 5HK264ADU8;
 				INFOPLIST_FILE = braise/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;

--- a/ios/braise/Info.plist
+++ b/ios/braise/Info.plist
@@ -35,7 +35,7 @@
 		<dict/>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>about</string>


### PR DESCRIPTION
Bumps `CFBundleVersion` to 1 for the 1.1 release ahead of TestFlight submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)