### PR TITLE
Fix share extension import flow end-to-end

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -28,7 +28,7 @@ import {Theme} from './theme/types';
 import {supabase} from './src/supabase-client';
 import {Session} from '@supabase/supabase-js';
 import Auth from './src/components/Auth';
-import {NativeModules, Platform} from 'react-native';
+import {NativeModules, Platform, DeviceEventEmitter} from 'react-native';
 import Purchases, {LOG_LEVEL} from 'react-native-purchases';
 import {useSubscription} from './src/hooks/useSubscription';
 import {isTablet, useHeaderStatusBarHeight} from './src/hooks/useTablet';
@@ -310,6 +310,15 @@ export default function App({}: AppProps): React.JSX.Element {
       handleResetPasswordUrl(url);
     });
 
+    const importSubscription = DeviceEventEmitter.addListener(
+      'ImportCompleted',
+      (recipe: any) => {
+        if (navigationRef.current?.isReady()) {
+          navigationRef.current.navigate('RecipeDetailsScreen', {item: recipe});
+        }
+      },
+    );
+
     supabase.auth.getSession().then(async ({data: {session}}) => {
       setAuthSession(session);
       if (session) {
@@ -336,6 +345,7 @@ export default function App({}: AppProps): React.JSX.Element {
     return () => {
       subscription.unsubscribe();
       linkingSubscription.remove();
+      importSubscription.remove();
     };
   }, []);
 

--- a/ios/RecipeImportShareExtension/ShareViewController.swift
+++ b/ios/RecipeImportShareExtension/ShareViewController.swift
@@ -69,16 +69,60 @@ class ShareViewController: UIViewController {
     private func finishWithResult(success: Bool) {
         showResultAnimation(success: success) {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self.completeRequest()
+                if success, let url = URL(string: "braise://import-complete") {
+                    self.extensionContext?.open(url) { _ in
+                        self.completeRequest()
+                    }
+                } else {
+                    self.completeRequest()
+                }
             }
         }
     }
 
     private func saveAndFinish(_ recipe: [String: Any]) {
-        saveRecipeToSupabase(recipe) { [weak self] success, _ in
+        saveRecipeToSupabase(recipe) { [weak self] success, savedRecipe in
             guard let self = self else { return }
+            if success, let savedRecipe = savedRecipe {
+                if let sharedDefaults = UserDefaults(suiteName: "group.com.braise.recipe") {
+                    sharedDefaults.set(savedRecipe, forKey: "importedRecipe")
+                    sharedDefaults.synchronize()
+                }
+                self.structureIngredients(
+                    recipeId: savedRecipe["id"],
+                    ingredients: recipe["ingredients"] as? String
+                )
+            }
             self.finishWithResult(success: success)
         }
+    }
+
+    private func structureIngredients(recipeId: Any?, ingredients: String?) {
+        guard let recipeId = recipeId,
+              let ingredients = ingredients, !ingredients.isEmpty,
+              let sharedDefaults = UserDefaults(suiteName: "group.com.braise.recipe"),
+              let accessToken = sharedDefaults.string(forKey: "supabaseAccessToken"),
+              let supabaseURL = sharedDefaults.string(forKey: "supabaseURL"),
+              let apiURL = URL(string: "\(supabaseURL)/functions/v1/structure-ingredients") else {
+            return
+        }
+
+        let lines = ingredients.split(separator: "\n")
+            .map(String.init)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        guard !lines.isEmpty else { return }
+
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 30.0
+
+        let body: [String: Any] = ["recipe_id": recipeId, "ingredient_lines": lines]
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: body) else { return }
+        request.httpBody = jsonData
+
+        URLSession.shared.dataTask(with: request) { _, _, _ in }.resume()
     }
 
     // MARK: - HTML Extraction
@@ -195,9 +239,9 @@ class ShareViewController: UIViewController {
         }.resume()
     }
 
-    private func saveRecipeToSupabase(_ recipe: [String: Any], completion: @escaping (Bool, String?) -> Void) {
+    private func saveRecipeToSupabase(_ recipe: [String: Any], completion: @escaping (Bool, [String: Any]?) -> Void) {
         guard let sharedDefaults = UserDefaults(suiteName: "group.com.braise.recipe") else {
-            completion(false, "Failed to access App Group")
+            completion(false, nil)
             return
         }
 
@@ -205,7 +249,7 @@ class ShareViewController: UIViewController {
               let supabaseAnonKey = sharedDefaults.string(forKey: "supabaseAnonKey"),
               let accessToken = sharedDefaults.string(forKey: "supabaseAccessToken"),
               let userId = sharedDefaults.string(forKey: "supabaseUserId") else {
-            completion(false, "Missing Supabase credentials - app needs to store them in App Group")
+            completion(false, nil)
             return
         }
 
@@ -227,37 +271,30 @@ class ShareViewController: UIViewController {
         request.timeoutInterval = 30.0
 
         guard let jsonData = try? JSONSerialization.data(withJSONObject: processedRecipe) else {
-            completion(false, "Failed to encode recipe")
+            completion(false, nil)
             return
         }
 
         request.httpBody = jsonData
 
         URLSession.shared.dataTask(with: request) { data, response, error in
-            if let error = error {
-                completion(false, error.localizedDescription)
+            if error != nil {
+                completion(false, nil)
                 return
             }
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                completion(false, "Invalid response")
+                completion(false, nil)
                 return
             }
 
             if (200..<300).contains(httpResponse.statusCode) {
-                completion(true, nil)
+                let savedRecipe = data
+                    .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [[String: Any]] }
+                    .flatMap { $0.first }
+                completion(true, savedRecipe)
             } else {
-                let errorMessage: String
-                if let data = data, let errorJSON = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                   let message = errorJSON["message"] as? String {
-                    errorMessage = message
-                } else if let data = data, let errorString = String(data: data, encoding: .utf8) {
-                    errorMessage = errorString
-                } else {
-                    errorMessage = "HTTP \(httpResponse.statusCode)"
-                }
-
-                completion(false, errorMessage)
+                completion(false, nil)
             }
         }.resume()
     }

--- a/ios/RecipeImportShareExtension/ShareViewController.swift
+++ b/ios/RecipeImportShareExtension/ShareViewController.swift
@@ -81,11 +81,13 @@ class ShareViewController: UIViewController {
     }
 
     private func saveAndFinish(_ recipe: [String: Any]) {
-        saveRecipeToSupabase(recipe) { [weak self] success, savedRecipe in
-            guard let self = self else { return }
+        saveRecipeToSupabase(recipe) { success, savedRecipe in
             if success, let savedRecipe = savedRecipe {
-                if let sharedDefaults = UserDefaults(suiteName: "group.com.braise.recipe") {
-                    sharedDefaults.set(savedRecipe, forKey: "importedRecipe")
+                // Store as JSON Data — raw dict may contain NSNull values from Supabase
+                // which crash UserDefaults.set(_:forKey:)
+                if let sharedDefaults = UserDefaults(suiteName: "group.com.braise.recipe"),
+                   let jsonData = try? JSONSerialization.data(withJSONObject: savedRecipe) {
+                    sharedDefaults.set(jsonData, forKey: "importedRecipe")
                     sharedDefaults.synchronize()
                 }
                 self.structureIngredients(
@@ -200,8 +202,8 @@ class ShareViewController: UIViewController {
 
     private func fetchRecipeFromAPI(html: String, url: String?) {
         guard let sharedDefaults = UserDefaults(suiteName: "group.com.braise.recipe"),
-              let apiURLString = sharedDefaults.string(forKey: "recipeImportAPIURL"),
-              let apiURL = URL(string: apiURLString) else {
+              let supabaseURL = sharedDefaults.string(forKey: "supabaseURL"),
+              let apiURL = URL(string: "\(supabaseURL)/functions/v1/import-recipe") else {
             finishWithResult(success: false)
             return
         }
@@ -257,7 +259,7 @@ class ShareViewController: UIViewController {
         processedRecipe["user_id"] = userId
 
         guard let apiURL = URL(string: "\(supabaseURL)/rest/v1/recipes") else {
-            completion(false, "Invalid Supabase URL")
+            completion(false, nil)
             return
         }
 

--- a/ios/braise/AppDelegate.mm
+++ b/ios/braise/AppDelegate.mm
@@ -57,13 +57,16 @@
     // Read recipe from App Group UserDefaults
     NSUserDefaults *sharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.com.braise.recipe"];
     if (sharedDefaults) {
-      id recipeObj = [sharedDefaults objectForKey:@"importedRecipe"];
-      if (recipeObj) {
-        // Emit the event with the recipe
-        [self emitImportEvent:recipeObj retryCount:0];
-        // Clear the recipe from UserDefaults after reading
+      id stored = [sharedDefaults objectForKey:@"importedRecipe"];
+      if (stored) {
         [sharedDefaults removeObjectForKey:@"importedRecipe"];
         [sharedDefaults synchronize];
+        // Stored as JSON Data to handle null values from Supabase
+        NSData *data = [stored isKindOfClass:[NSData class]] ? stored : nil;
+        id recipeObj = data ? [NSJSONSerialization JSONObjectWithData:data options:0 error:nil] : stored;
+        if (recipeObj) {
+          [self emitImportEvent:recipeObj retryCount:0];
+        }
       }
     }
   }

--- a/src/components/RecipeViewer.tsx
+++ b/src/components/RecipeViewer.tsx
@@ -231,6 +231,23 @@ export default function RecipeViewer({
                       </View>
                     );
                   })
+                ) : data.ingredients && !isLoadingIngredients ? (
+                  data.ingredients
+                    .split('\n')
+                    .filter((l: string) => l.trim())
+                    .map((line: string, index: number, arr: string[]) => (
+                      <View
+                        style={[
+                          styles(theme).ingredientLine,
+                          index !== arr.length - 1 &&
+                            styles(theme).ingredientDivider,
+                        ]}
+                        key={index}>
+                        <Text style={styles(theme).ingredientText}>
+                          {line.trim()}
+                        </Text>
+                      </View>
+                    ))
                 ) : isLoadingIngredients ? null : (
                   <View style={styles(theme).emptyStateContainer}>
                     <Text style={styles(theme).emptyStateText}>


### PR DESCRIPTION
## Summary

Three issues fixed:

- **Regression (RecipeViewer)**: After importing via share extension, the viewer was showing "No ingredients found" because `structuredIngredients` is empty until the recipe is saved from the main app. Added a fallback that displays the raw `data.ingredients` lines when no structured ingredients exist — restoring the previous behavior while keeping the structured display for saved recipes.

- **Share extension (ShareViewController)**: After successfully saving to Supabase, the extension now parses the returned recipe dict, stores it in App Group UserDefaults under `importedRecipe`, fires a background call to `structure-ingredients` (so ingredients are ready when the user opens the recipe), then opens `braise://import-complete` to bring the main app to the foreground. Previously none of this happened — the extension just closed silently.

- **App.tsx**: Added a `DeviceEventEmitter` listener for `ImportCompleted` (already emitted by AppDelegate when `braise://import-complete` is opened) that navigates directly to `RecipeDetailsScreen` with the imported recipe. Previously the event was emitted but nothing in JS handled it.

## Test plan

- [ ] Share a recipe URL from Safari → Braise extension appears, shows loading spinner
- [ ] Extension shows green checkmark → Braise opens automatically and navigates to the imported recipe
- [ ] Recipe ingredients display correctly (either structured or raw fallback)
- [ ] After the recipe is saved once from the main app, structured ingredients replace the raw lines
- [ ] Sharing from an app that only provides a URL (no HTML) still works via the server-side fetch path

🤖 Generated with [Claude Code](https://claude.com/claude-code)