### PR TITLE
Bump build number to 1.1 (2)

### DIFF
--- a/ios/braise.xcodeproj/project.pbxproj
+++ b/ios/braise.xcodeproj/project.pbxproj
@@ -637,7 +637,7 @@
 				CODE_SIGN_ENTITLEMENTS = braise/braise.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 5HK264ADU8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = braise/Info.plist;
@@ -674,7 +674,7 @@
 				CODE_SIGN_ENTITLEMENTS = braise/braise.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 5HK264ADU8;
 				INFOPLIST_FILE = braise/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
@@ -713,7 +713,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = RecipeImportShareExtension/RecipeImportShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = NO;
 				DEVELOPMENT_TEAM = 5HK264ADU8;
@@ -762,7 +762,7 @@
 				CODE_SIGN_ENTITLEMENTS = RecipeImportShareExtension/RecipeImportShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = NO;
 				DEVELOPMENT_TEAM = 5HK264ADU8;

--- a/ios/braise/Info.plist
+++ b/ios/braise/Info.plist
@@ -35,7 +35,7 @@
 		<dict/>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>about</string>

--- a/ios/braiseTests/Info.plist
+++ b/ios/braiseTests/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>TAYTommyTokyo.otf</string>


### PR DESCRIPTION
## Summary
- Bumps `CURRENT_PROJECT_VERSION` to 2 across all targets for TestFlight submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)